### PR TITLE
Add Function Expression rule

### DIFF
--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -115,6 +115,11 @@ module.exports = {
       allowTaggedTemplates: false,
     }],
     'no-unused-labels': 'error',
+    'no-use-before-define': ['error', {
+      'functions': true,
+      'classes': true,
+      'variables': true
+    }],
     'no-useless-concat': 'error',
     'no-useless-return': 'error',
     'no-void': 'error',
@@ -154,8 +159,9 @@ module.exports = {
     'no-eval': 'error',
     'no-useless-escape': 'error',
     'func-style': [
-      'off',
-      'expression'
+      'error',
+      'expression',
+      { 'allowArrowFunctions': true }
     ],
     'wrap-iife': [
       'error',

--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -158,6 +158,7 @@ module.exports = {
     ],
     'no-eval': 'error',
     'no-useless-escape': 'error',
+    'func-names': ['error', 'as-needed'],
     'func-style': [
       'error',
       'expression',


### PR DESCRIPTION
With these rules, we will only permit function expressions.

- func-style: we're using this explanation from [Airbnb](https://github.com/airbnb/javascript#functions--declarations) to enable this rule
- no-use-before-define: necessary to avoid errors with hoisting ([eslint](https://eslint.org/docs/rules/no-use-before-define#disallow-early-use-no-use-before-define))
- func-names: necessary to avoid function name inference ([eslint](https://eslint.org/docs/rules/func-names#require-or-disallow-named-function-expressions-func-names))