### PR TITLE
Adicionando regras para padronização de import/export

### DIFF
--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -283,6 +283,35 @@ module.exports = {
     ],
     'no-var': 'error',
     'no-useless-call': 'error',
-    'strict': 'error'
+    'strict': 'error',
+    //import rules
+    'import/first': 'error',
+    'import/imports-first': 'off',
+    'import/no-mutable-exports': 'error',
+    'import/order': ['error', {
+      'groups': [
+        [
+          'builtin',
+          'external',
+          'parent',
+          'internal'
+        ]
+      ]
+    }],
+    'import/newline-after-import': 'error',
+    'import/no-absolute-path': 'error',
+    'import/no-internal-modules': ['off', { 'allow': [] }],
+    'import/no-anonymous-default-export': ['off',
+      {
+        'allowArray': false,
+        'allowArrowFunction': false,
+        'allowAnonymousClass': false,
+        'allowAnonymousFunction': false,
+        'allowLiteral': false,
+        'allowObject': false
+      }
+    ],
+    'import/no-useless-path-segments': 'error',
+    'import/no-relative-parent-imports': 'off'
   }
 }

--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -284,9 +284,7 @@ module.exports = {
     'no-var': 'error',
     'no-useless-call': 'error',
     'strict': 'error',
-    //import rules
     'import/first': 'error',
-    'import/imports-first': 'off',
     'import/no-mutable-exports': 'error',
     'import/order': ['error', {
       'newlines-between': 'never',
@@ -294,14 +292,16 @@ module.exports = {
         [
           'builtin',
           'external',
+          'internal',
           'parent',
-          'internal'
+          'sibling',
+          'index'
         ]
       ]
     }],
     'import/newline-after-import': 'error',
     'import/no-absolute-path': 'error',
-    'import/no-internal-modules': ['off', { 'allow': [] }],
+    'import/no-internal-modules': 'off',
     'import/no-anonymous-default-export': ['off',
       {
         'allowArray': false,
@@ -312,7 +312,9 @@ module.exports = {
         'allowObject': false
       }
     ],
-    'import/no-useless-path-segments': 'error',
+    'import/no-useless-path-segments': ['error', {
+      'noUselessIndex': true
+    }],
     'import/no-relative-parent-imports': 'off'
   }
 }

--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -302,14 +302,14 @@ module.exports = {
     'import/newline-after-import': 'error',
     'import/no-absolute-path': 'error',
     'import/no-internal-modules': 'off',
-    'import/no-anonymous-default-export': ['off',
+    'import/no-anonymous-default-export': ['error',
       {
         'allowArray': false,
         'allowArrowFunction': false,
         'allowAnonymousClass': false,
         'allowAnonymousFunction': false,
         'allowLiteral': false,
-        'allowObject': false
+        'allowObject': true
       }
     ],
     'import/no-useless-path-segments': ['error', {

--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -289,6 +289,7 @@ module.exports = {
     'import/imports-first': 'off',
     'import/no-mutable-exports': 'error',
     'import/order': ['error', {
+      'newlines-between': 'never',
       'groups': [
         [
           'builtin',


### PR DESCRIPTION
Algumas regras foram baseadas no eslint base do Airbnb e outras regras melhoradas conforme o uso nos projetos: https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/imports.js