### PR TITLE
feat(sort): remove sort-(vars/keys/imports) rules

### DIFF
--- a/rules/gandalf.js
+++ b/rules/gandalf.js
@@ -270,13 +270,6 @@ module.exports = {
       'error',
       'event'
     ],
-    'sort-keys': 'error',
-    'sort-vars': 'error',
-    'sort-imports': ['error', {
-      'ignoreCase': true,
-      'ignoreDeclarationSort': true,
-      'ignoreMemberSort': false,
-    }],
     'complexity': [
       'error',
       4


### PR DESCRIPTION
- sort-vars is useless since we use one-var rule;
- sort-keys: we realize this rule does not help on code quality;
- sort-imports: we use eslint-plugin-import to manage import rules.